### PR TITLE
Remove redundant symfony/polyfill-php83 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     "mashape/unirest-php": "^3.0.4",
     "ptlis/diff-parser": "^1.1.0",
     "symfony/console": "^6.4|^7.4",
-    "symfony/polyfill-php83": "^1.31",
     "symfony/polyfill-uuid": "^1.31.0",
     "webmozart/assert": "^1.11.0"
   },


### PR DESCRIPTION
This package depends on `symfony/polyfill-php83`, but also `php: ^8.3`, so the polyfill requirement doesn't seem necessary anymore?